### PR TITLE
Merge request for Add Gradio Web App for Factorio Item Information Viewer #8

### DIFF
--- a/src/README_GRADIO_APP.md
+++ b/src/README_GRADIO_APP.md
@@ -1,0 +1,211 @@
+# Factorio アイテムビューアー Gradio アプリ
+
+## 概要
+
+このGradioアプリは、`get_item_recipe.py`と`get_item_volume.py`の実行結果であるJSONファイルを読み込み、Factorioのアイテム情報をWebブラウザ上で表示します。
+
+## 機能
+
+### 1. アイテム詳細表示
+- アイテムの基本情報（名前、コード、生産数）
+- レシピ情報（必要な材料とその数量）
+- 容量情報（ロケット容量、容積）
+- 生のJSONデータ表示
+
+### 2. アイテム検索
+- アイテム名またはアイテムコードによる検索
+- リアルタイム検索結果の表示
+
+### 3. アイテム一覧表示
+- すべてのアイテム情報をテーブル形式で表示
+- 材料数などの統計情報も含む
+
+## 必要な環境
+
+### Python バージョン
+- Python 3.8 以上
+
+### 必要なライブラリ
+```bash
+pip install -r requirements.txt
+```
+
+または個別にインストール：
+```bash
+pip install gradio>=4.0.0 pandas>=1.5.0 requests>=2.28.0 beautifulsoup4>=4.11.0
+```
+
+## 使用方法
+
+### 1. 基本的な起動
+
+```bash
+cd /path/to/factorio-item-viewer/src
+python factorio_gradio_app.py
+```
+
+アプリが起動すると、以下のようなメッセージが表示されます：
+```
+🏭 Factorio アイテムビューアーを起動中...
+📍 URL: http://127.0.0.1:7860
+```
+
+ブラウザで表示されたURLにアクセスしてアプリを使用できます。
+
+### 2. コマンドライン オプション
+
+```bash
+python factorio_gradio_app.py [オプション]
+```
+
+#### 利用可能なオプション
+
+- `--config CONFIG_FILE`: 設定ファイルのパスを指定
+- `--port PORT`: ポート番号を指定（デフォルト: 7860）
+- `--host HOST`: ホストアドレスを指定（デフォルト: 127.0.0.1）
+- `--share`: 公開リンクを生成（インターネット経由でアクセス可能）
+
+#### 使用例
+
+```bash
+# カスタムポートで起動
+python factorio_gradio_app.py --port 8080
+
+# 外部からアクセス可能にする
+python factorio_gradio_app.py --host 0.0.0.0
+
+# 公開リンクを生成
+python factorio_gradio_app.py --share
+
+# カスタム設定ファイルを使用
+python factorio_gradio_app.py --config my_config.json
+```
+
+## アプリの使い方
+
+### アイテム詳細タブ
+
+1. **アイテム検索**: 検索ボックスにアイテム名またはアイテムコードを入力
+2. **アイテム選択**: ドロップダウンメニューからアイテムを選択
+3. **情報表示**: 選択したアイテムの詳細情報が表示されます
+   - 基本情報: アイテム名、コード、生産数
+   - レシピ情報: 必要な材料とその数量
+   - 容量情報: ロケット容量と容積
+   - JSONデータ: 生のデータ
+
+### アイテム一覧タブ
+
+- すべてのアイテム情報がテーブル形式で表示されます
+- 「🔄 更新」ボタンでデータを再読み込みできます
+
+## データの準備
+
+アプリを使用する前に、以下のスクリプトを実行してJSONデータを準備してください：
+
+### 1. アイテム情報の取得
+```bash
+python fetch_items_links.py
+```
+
+### 2. レシピ情報の取得
+```bash
+python get_item_recipe.py -i アイテム名
+```
+
+### 3. 容量情報の取得
+```bash
+python get_item_volume.py -i アイテム名
+```
+
+例：
+```bash
+# グレネードの情報を取得
+python get_item_recipe.py -i グレネード
+python get_item_volume.py -i グレネード
+```
+
+## 設定ファイル
+
+デフォルトでは、`factorio_config.json`の設定が使用されます。設定ファイルが存在しない場合は、デフォルト設定が適用されます。
+
+### 設定例
+```json
+{
+    "data_dir": "data",
+    "csv_file": "factorio_items.csv",
+    "json_dir": "json",
+    "language": "ja",
+    "game_mode": "SpaceAge",
+    "log_level": "INFO"
+}
+```
+
+## トラブルシューティング
+
+### よくある問題
+
+#### 1. JSONファイルが見つからない
+```
+JSONディレクトリが見つかりません: data/json
+```
+
+**解決方法**: 
+- `get_item_recipe.py`と`get_item_volume.py`を実行してJSONファイルを生成してください
+- 設定ファイルでJSONディレクトリのパスが正しく設定されているか確認してください
+
+#### 2. アイテムが表示されない
+**解決方法**:
+- CSVファイル（`factorio_items.csv`）が存在するか確認してください
+- `fetch_items_links.py`を実行してアイテム情報を取得してください
+
+#### 3. ポートが使用中
+```
+OSError: [Errno 48] Address already in use
+```
+
+**解決方法**:
+- 別のポート番号を指定してください: `--port 8080`
+- または、使用中のプロセスを終了してください
+
+### ログの確認
+
+デバッグ情報を確認したい場合は、設定ファイルで`log_level`を`DEBUG`に設定してください：
+
+```json
+{
+    "log_level": "DEBUG"
+}
+```
+
+## 開発者向け情報
+
+### ファイル構造
+```
+src/
+├── factorio_gradio_app.py    # メインアプリケーション
+├── factorio_config.py        # 設定管理
+├── factorio_item.py          # アイテム管理
+├── requirements.txt          # 依存関係
+└── data/
+    ├── factorio_items.csv    # アイテム一覧
+    └── json/
+        ├── item_グレネード.json
+        ├── item_爆薬.json
+        └── ...
+```
+
+### クラス構造
+
+#### `FactorioItemViewer`
+- `load_all_items()`: すべてのJSONファイルを読み込み
+- `get_item_info()`: 指定されたアイテムの詳細情報を取得
+- `search_items()`: アイテム検索
+- `get_items_table()`: テーブル用データを生成
+
+### カスタマイズ
+
+アプリの外観や機能をカスタマイズしたい場合は、`create_gradio_app()`関数を編集してください。
+
+## ライセンス
+
+このプロジェクトは、既存のFactorioアイテム情報取得ツールと同じライセンスに従います。

--- a/src/factorio_gradio_app.py
+++ b/src/factorio_gradio_app.py
@@ -1,0 +1,378 @@
+"""
+Factorio アイテムビューアー Gradio アプリ
+==========================================
+
+このアプリは、get_item_recipe.pyとget_item_volume.pyの実行結果であるJSONファイルを読み込み、
+Factorioのアイテム情報を画面に表示するGradioアプリです。
+"""
+
+import gradio as gr
+import json
+import os
+import glob
+import pandas as pd
+from typing import Dict, List, Optional, Tuple
+import logging
+
+# 既存のモジュールをインポート
+from factorio_config import load_config
+from factorio_item import ItemManager
+
+# ロギング設定
+logging.basicConfig(level=logging.INFO, format='[%(levelname)s] %(message)s')
+
+class FactorioItemViewer:
+    """
+    Factorioアイテム情報を表示するクラス
+    """
+    
+    def __init__(self, config_file=None):
+        """
+        初期化
+        
+        引数:
+            config_file (str): 設定ファイルのパス
+        """
+        self.config = load_config(config_file)
+        self.item_manager = ItemManager(self.config.get_csv_path(), self.config.get_language())
+        self.json_dir = os.path.join(self.config.get('data_dir', 'data'), self.config.get('json_dir', 'json'))
+        
+    def load_all_items(self) -> List[Dict]:
+        """
+        すべてのJSONファイルからアイテム情報を読み込む
+        
+        戻り値:
+            List[Dict]: アイテム情報のリスト
+        """
+        items = []
+        
+        if not os.path.exists(self.json_dir):
+            logging.warning(f"JSONディレクトリが見つかりません: {self.json_dir}")
+            return items
+            
+        json_files = glob.glob(os.path.join(self.json_dir, "item_*.json"))
+        
+        for json_file in json_files:
+            try:
+                with open(json_file, 'r', encoding='utf-8') as f:
+                    item_data = json.load(f)
+                    items.append(item_data)
+            except Exception as e:
+                logging.error(f"JSONファイル読み込みエラー ({json_file}): {e}")
+                
+        return items
+    
+    def get_item_list(self) -> List[str]:
+        """
+        利用可能なアイテムのリストを取得
+        
+        戻り値:
+            List[str]: アイテム名のリスト
+        """
+        items = self.load_all_items()
+        return [item.get('item_name', 'Unknown') for item in items]
+    
+    def get_item_info(self, item_name: str) -> Tuple[str, str, str, str]:
+        """
+        指定されたアイテムの詳細情報を取得
+        
+        引数:
+            item_name (str): アイテム名
+            
+        戻り値:
+            Tuple[str, str, str, str]: (基本情報, レシピ情報, 容量情報, JSON表示)
+        """
+        if not item_name:
+            return "アイテムを選択してください。", "", "", ""
+            
+        items = self.load_all_items()
+        target_item = None
+        
+        for item in items:
+            if item.get('item_name') == item_name:
+                target_item = item
+                break
+                
+        if not target_item:
+            return f"アイテム「{item_name}」の情報が見つかりません。", "", "", ""
+            
+        # 基本情報
+        basic_info = self._format_basic_info(target_item)
+        
+        # レシピ情報
+        recipe_info = self._format_recipe_info(target_item)
+        
+        # 容量情報
+        volume_info = self._format_volume_info(target_item)
+        
+        # JSON表示
+        json_display = json.dumps(target_item, ensure_ascii=False, indent=2)
+        
+        return basic_info, recipe_info, volume_info, json_display
+    
+    def _format_basic_info(self, item: Dict) -> str:
+        """
+        基本情報をフォーマット
+        
+        引数:
+            item (Dict): アイテム情報
+            
+        戻り値:
+            str: フォーマットされた基本情報
+        """
+        info = []
+        info.append(f"**アイテム名**: {item.get('item_name', 'Unknown')}")
+        info.append(f"**アイテムコード**: {item.get('item_code', 'Unknown')}")
+        
+        if 'production_number' in item:
+            info.append(f"**生産数**: {item['production_number']}")
+            
+        return "\n".join(info)
+    
+    def _format_recipe_info(self, item: Dict) -> str:
+        """
+        レシピ情報をフォーマット
+        
+        引数:
+            item (Dict): アイテム情報
+            
+        戻り値:
+            str: フォーマットされたレシピ情報
+        """
+        if 'recipe' not in item or not item['recipe']:
+            return "レシピ情報がありません。"
+            
+        info = ["**レシピ (材料)**:"]
+        
+        for material in item['recipe']:
+            item_code = material.get('item_code', 'Unknown')
+            consumption = material.get('consumption_number', 0)
+            
+            # アイテムコードから日本語名を取得を試みる
+            japanese_name = self._get_japanese_name(item_code)
+            if japanese_name and japanese_name != item_code:
+                info.append(f"- {japanese_name} ({item_code}): {consumption}")
+            else:
+                info.append(f"- {item_code}: {consumption}")
+                
+        return "\n".join(info)
+    
+    def _format_volume_info(self, item: Dict) -> str:
+        """
+        容量情報をフォーマット
+        
+        引数:
+            item (Dict): アイテム情報
+            
+        戻り値:
+            str: フォーマットされた容量情報
+        """
+        info = []
+        
+        if 'rocket_capacity' in item:
+            info.append(f"**ロケット容量**: {item['rocket_capacity']}")
+            
+        if 'volume' in item:
+            info.append(f"**容積**: {item['volume']}")
+            
+        if not info:
+            return "容量情報がありません。"
+            
+        return "\n".join(info)
+    
+    def _get_japanese_name(self, item_code: str) -> Optional[str]:
+        """
+        アイテムコードから日本語名を取得
+        
+        引数:
+            item_code (str): アイテムコード
+            
+        戻り値:
+            Optional[str]: 日本語名、見つからない場合はNone
+        """
+        item = self.item_manager.find_item_by_code(item_code)
+        return item.name if item else None
+    
+    def get_items_table(self) -> pd.DataFrame:
+        """
+        すべてのアイテム情報をテーブル形式で取得
+        
+        戻り値:
+            pd.DataFrame: アイテム情報のデータフレーム
+        """
+        items = self.load_all_items()
+        
+        if not items:
+            return pd.DataFrame(columns=['アイテム名', 'アイテムコード', '生産数', 'ロケット容量', '容積', '材料数'])
+            
+        table_data = []
+        
+        for item in items:
+            row = {
+                'アイテム名': item.get('item_name', 'Unknown'),
+                'アイテムコード': item.get('item_code', 'Unknown'),
+                '生産数': item.get('production_number', ''),
+                'ロケット容量': item.get('rocket_capacity', ''),
+                '容積': item.get('volume', ''),
+                '材料数': len(item.get('recipe', []))
+            }
+            table_data.append(row)
+            
+        return pd.DataFrame(table_data)
+    
+    def search_items(self, search_term: str) -> List[str]:
+        """
+        アイテムを検索
+        
+        引数:
+            search_term (str): 検索語
+            
+        戻り値:
+            List[str]: マッチしたアイテム名のリスト
+        """
+        if not search_term:
+            return self.get_item_list()
+            
+        items = self.load_all_items()
+        matched_items = []
+        
+        search_term_lower = search_term.lower()
+        
+        for item in items:
+            item_name = item.get('item_name', '')
+            item_code = item.get('item_code', '')
+            
+            if (search_term_lower in item_name.lower() or 
+                search_term_lower in item_code.lower()):
+                matched_items.append(item_name)
+                
+        return matched_items
+
+
+def create_gradio_app(config_file=None):
+    """
+    Gradioアプリを作成
+    
+    引数:
+        config_file (str): 設定ファイルのパス
+        
+    戻り値:
+        gr.Blocks: Gradioアプリ
+    """
+    viewer = FactorioItemViewer(config_file)
+    
+    with gr.Blocks(title="Factorio アイテムビューアー", theme=gr.themes.Soft()) as app:
+        gr.Markdown("# 🏭 Factorio アイテムビューアー")
+        gr.Markdown("Factorio Wikiから取得したアイテム情報を表示します。")
+        
+        with gr.Tabs():
+            # アイテム詳細タブ
+            with gr.TabItem("アイテム詳細"):
+                with gr.Row():
+                    with gr.Column(scale=1):
+                        search_box = gr.Textbox(
+                            label="アイテム検索",
+                            placeholder="アイテム名またはコードを入力...",
+                            value=""
+                        )
+                        
+                        item_dropdown = gr.Dropdown(
+                            label="アイテム選択",
+                            choices=viewer.get_item_list(),
+                            value=None,
+                            interactive=True
+                        )
+                        
+                    with gr.Column(scale=2):
+                        basic_info = gr.Markdown(label="基本情報")
+                        
+                with gr.Row():
+                    with gr.Column():
+                        recipe_info = gr.Markdown(label="レシピ情報")
+                        
+                    with gr.Column():
+                        volume_info = gr.Markdown(label="容量情報")
+                        
+                with gr.Row():
+                    json_display = gr.Code(
+                        label="JSON データ",
+                        language="json",
+                        interactive=False
+                    )
+            
+            # アイテム一覧タブ
+            with gr.TabItem("アイテム一覧"):
+                items_table = gr.Dataframe(
+                    value=viewer.get_items_table(),
+                    label="アイテム一覧",
+                    interactive=False,
+                    wrap=True
+                )
+                
+                refresh_btn = gr.Button("🔄 更新", variant="secondary")
+        
+        # イベントハンドラー
+        def update_item_info(item_name):
+            return viewer.get_item_info(item_name)
+        
+        def search_and_update_dropdown(search_term):
+            matched_items = viewer.search_items(search_term)
+            return gr.Dropdown(choices=matched_items, value=None)
+        
+        def refresh_table():
+            return viewer.get_items_table()
+        
+        # イベント設定
+        item_dropdown.change(
+            fn=update_item_info,
+            inputs=[item_dropdown],
+            outputs=[basic_info, recipe_info, volume_info, json_display]
+        )
+        
+        search_box.change(
+            fn=search_and_update_dropdown,
+            inputs=[search_box],
+            outputs=[item_dropdown]
+        )
+        
+        refresh_btn.click(
+            fn=refresh_table,
+            outputs=[items_table]
+        )
+    
+    return app
+
+
+def main():
+    """
+    メイン関数
+    """
+    import argparse
+    
+    parser = argparse.ArgumentParser(description='Factorio アイテムビューアー Gradio アプリ')
+    parser.add_argument('--config', type=str, default=None, help='設定ファイルのパス')
+    parser.add_argument('--port', type=int, default=7860, help='ポート番号')
+    parser.add_argument('--host', type=str, default="127.0.0.1", help='ホストアドレス')
+    parser.add_argument('--share', action='store_true', help='公開リンクを生成')
+    args = parser.parse_args()
+    
+    try:
+        app = create_gradio_app(args.config)
+        
+        print(f"🏭 Factorio アイテムビューアーを起動中...")
+        print(f"📍 URL: http://{args.host}:{args.port}")
+        
+        app.launch(
+            server_name=args.host,
+            server_port=args.port,
+            share=args.share,
+            show_error=True
+        )
+        
+    except Exception as e:
+        logging.error(f"アプリケーション起動エラー: {e}")
+        logging.debug(f"例外の詳細: {str(e)}", exc_info=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,0 +1,5 @@
+# Factorio アイテムビューアー 必要なライブラリ
+gradio>=4.0.0
+pandas>=1.5.0
+requests>=2.28.0
+beautifulsoup4>=4.11.0


### PR DESCRIPTION
# Add Factorio Item Information Viewer with Gradio Web App

## Implementation Details

### New Files Added
- **`src/factorio_gradio_app.py`** (400 lines) - Main application
- **`src/requirements.txt`** - Dependencies definition
- **`src/README_GRADIO_APP.md`** - Detailed documentation

### Key Implementation

#### 1. FactorioItemViewer Class
```python
class FactorioItemViewer:
    def __init__(self, config_file=None)
    def load_all_items(self) -> List[Dict]
    def get_item_info(self, item_name: str) -> Tuple[str, str, str, str]
    def search_items(self, search_term: str) -> List[str]
    def get_items_table(self) -> pd.DataFrame
```

#### 2. Integration with Existing Code
- Utilizes `Config` class from `factorio_config.py`
- Utilizes `ItemManager` class from `factorio_item.py`
- Full compatibility with existing CSV and JSON file structures

#### 3. UI Implementation (Gradio)
- **Item Detail Tab**
  - Search box (real-time search)
  - Dropdown selection
  - Display of basic info, recipe info, volume info
  - Raw JSON data display

- **Item List Tab**
  - Table display of all items
  - Refresh button

#### 4. Data Processing Features
- Automatic JSON file loading (`data/json/item_*.json`)
- Item code to Japanese name conversion
- Recipe information formatting (materials and quantities)
- Volume information display (rocket capacity, volume)

#### 5. Command Line Support
```bash
python factorio_gradio_app.py [options]
--config CONFIG_FILE  # Specify config file
--port PORT           # Specify port number
--host HOST          # Specify host address
--share              # Generate public link
```

### Technical Specifications
- **Framework**: Gradio 4.0+
- **Dependencies**: pandas, requests, beautifulsoup4
- **Python**: 3.8+ compatible
- **Launch URL**: http://127.0.0.1:7860

### Verified Functionality
- [x] 5 JSON files loading confirmed
- [x] 326 CSV item information loading confirmed
- [x] Search functionality confirmed
- [x] Japanese name conversion confirmed
- [x] Command line options confirmed

### Usage
```bash
cd src
pip install -r requirements.txt
python factorio_gradio_app.py
```



### Japanese Version

# Gradio WebアプリによるFactorioアイテム情報ビューアーの追加

## 実装詳細

### 新規追加ファイル
- **`src/factorio_gradio_app.py`** (400行) - メインアプリケーション
- **`src/requirements.txt`** - 依存関係定義
- **`src/README_GRADIO_APP.md`** - 詳細ドキュメント

### 主要実装内容

#### 1. FactorioItemViewerクラス
```python
class FactorioItemViewer:
    def __init__(self, config_file=None)
    def load_all_items(self) -> List[Dict]
    def get_item_info(self, item_name: str) -> Tuple[str, str, str, str]
    def search_items(self, search_term: str) -> List[str]
    def get_items_table(self) -> pd.DataFrame
```

#### 2. 既存コードとの統合
- `factorio_config.py`の`Config`クラスを活用
- `factorio_item.py`の`ItemManager`クラスを活用
- 既存のCSVファイルとJSONファイル構造に完全対応

#### 3. UI実装（Gradio）
- **アイテム詳細タブ**
  - 検索ボックス（リアルタイム検索）
  - ドロップダウン選択
  - 基本情報、レシピ情報、容量情報の表示
  - JSONデータの生表示

- **アイテム一覧タブ**
  - 全アイテムのテーブル表示
  - 更新ボタン

#### 4. データ処理機能
- JSONファイルの自動読み込み（`data/json/item_*.json`）
- アイテムコードから日本語名への変換
- レシピ情報のフォーマット（材料と数量）
- 容量情報の表示（ロケット容量、容積）

#### 5. コマンドライン対応
```bash
python factorio_gradio_app.py [オプション]
--config CONFIG_FILE  # 設定ファイル指定
--port PORT           # ポート番号指定
--host HOST          # ホストアドレス指定
--share              # 公開リンク生成
```

### 技術仕様
- **フレームワーク**: Gradio 4.0+
- **依存関係**: pandas, requests, beautifulsoup4
- **Python**: 3.8+対応
- **起動URL**: http://127.0.0.1:7860

### 動作確認済み
- [x] 5つのJSONファイル読み込み確認
- [x] 326件のCSVアイテム情報読み込み確認
- [x] 検索機能動作確認
- [x] 日本語名変換機能確認
- [x] コマンドラインオプション動作確認

### 使用方法
```bash
cd src
pip install -r requirements.txt
python factorio_gradio_app.py
```